### PR TITLE
Fix run command in README (missing arguments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ mvn clean install
 ### ▶️ To run
 
 ```bash
-mvn exec:java -Dexec.mainClass="cache.Main"
+mvn exec:java -Dexec.mainClass="cache.Main" -Dexec.args="cache-config.json traces/sample_trace.txt"
 ```
 
 ## 🧾 Example Output


### PR DESCRIPTION
### 📝 Fix

- Added missing `exec.args` to the `mvn exec:java` command in README

No other changes included.
