### PR TITLE
Add CacheHierarchy to support multilevel cache access (#6)

### DIFF
--- a/src/main/java/cache/Main.java
+++ b/src/main/java/cache/Main.java
@@ -3,7 +3,8 @@ package cache;
 import cache.config.CacheConfig;
 import cache.config.CacheLevelConfig;
 import cache.utils.TraceReader;
-import cache.simulator.CacheLevel;
+import cache.simulator.CacheHierarchy;
+//import cache.simulator.CacheLevel;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -42,29 +43,23 @@ public class Main {
             System.out.println("First 5 addresses:");
             addresses.stream().limit(5).forEach(addr -> System.out.printf("  0x%X\n", addr));
 
-            CacheLevel l1 = new CacheLevel(config.levels.get(0));
+            CacheHierarchy hierarchy = new CacheHierarchy(config);
 
-            int total = 0;
             for (long addr : addresses) {
-                boolean hit = l1.access(addr);
-                System.out.printf("Access 0x%X => %s\n", addr, hit ? "HIT" : "MISS");
-                total++;
+
+                hierarchy.access(addr);
             }
 
-            
             System.out.println("\n=== Simulation Complete ===");
-            System.out.println("Total accesses: " + total);
-            System.out.println("Hits: " + l1.getHits());
-            System.out.println("Misses: " + l1.getMisses());
-            
-            double hitRate = total == 0 ? 0.0 : (100.0 * l1.getHits() / total);
-            System.out.printf("Hit rate: %.2f%%\n", hitRate);
-            
-            l1.printStats();
+            System.out.println("Total accesses: " + hierarchy.getTotalAccesses());
+            hierarchy.printStats();
+
+            System.out.printf("Overall L1 Hit Rate: %.2f%%\n", hierarchy.getOverallHitRate());
 
         } catch (Exception e) {
             System.err.println("Error:");
             e.printStackTrace();
         }
     }
+
 }

--- a/src/main/java/cache/simulator/CacheHierarchy.java
+++ b/src/main/java/cache/simulator/CacheHierarchy.java
@@ -1,0 +1,55 @@
+package cache.simulator;
+
+import cache.config.CacheConfig;
+import cache.config.CacheLevelConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simulates a multi-level cache hierarchy (e.g. L1 → L2 → ...).
+ */
+public class CacheHierarchy {
+    private final List<CacheLevel> levels = new ArrayList<>();
+
+    public CacheHierarchy(CacheConfig config) {
+        for (CacheLevelConfig levelConfig : config.levels) {
+            levels.add(new CacheLevel(levelConfig));
+        }
+    }
+
+    /**
+     * Attempts to access the address in the cache hierarchy.
+     * Returns true if any level hits.
+     */
+    public boolean access(long address) {
+        for (int i = 0; i < levels.size(); i++) {
+            boolean hit = levels.get(i).access(address);
+            if (hit) {
+                // Optionally: promote to upper level in future versions
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void printStats() {
+        for (CacheLevel level : levels) {
+            level.printStats();
+        }
+    }
+
+    public int getTotalAccesses() {
+        if (levels.isEmpty())
+            return 0;
+        return levels.get(0).getHits() + levels.get(0).getMisses();
+    }
+
+    public double getOverallHitRate() {
+        if (levels.isEmpty())
+            return 0.0;
+        int total = levels.get(0).getHits() + levels.get(0).getMisses();
+        return total == 0 ? 0.0 : (100.0 * levels.get(0).getHits() / total);
+    }
+
+}


### PR DESCRIPTION
### ✅ Description

- Created `CacheHierarchy` class to manage multiple cache levels
- On access, tries each level sequentially (L1 → L2 → ...)
- Prints separate statistics for each level
- Updated `Main` to use hierarchy instead of single `CacheLevel`

Closes #13 